### PR TITLE
Copilot/sub pr 3

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
     {
       "label": "Build + commit funnel map",
       "type": "shell",
-      "command": "python3 scripts/build_funnel_map.py && git diff --quiet docs/checklists/funnel_map.md || (git add docs/checklists/funnel_map.md && git commit -m \"docs: update funnel map\")",
+      "command": "${config:python.defaultInterpreterPath} scripts/build_funnel_map.py && git diff --quiet docs/checklists/funnel_map.md || (git add docs/checklists/funnel_map.md && git commit -m \"docs: update funnel map\")",
       "options": {
         "cwd": "${workspaceFolder}"
       },


### PR DESCRIPTION
This pull request makes a minor update to the VS Code tasks configuration. The change ensures that the Python interpreter used for the "Build + commit funnel map" task is determined by the workspace's Python settings, improving compatibility across different development environments.

- Updated the `command` in `.vscode/tasks.json` to use `${config:python.defaultInterpreterPath}` instead of hardcoding `python3`, allowing the task to respect the user's selected Python interpreter.